### PR TITLE
Block signals during file rotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,14 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 app = "0.6.5"
+libc = "0.2.139"
 # XXX tempfile is only required for the test helper binary, but there's not way
 # (yet) to only compile the binary if building with tests enabled.
 tempfile = "3.3.0"
 
 [dev-dependencies]
 lang_tester = "0.7.1"
+rand = "0.8.5"
 
 [[test]]
 name = "lang_tests"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rotee
 
 `rotee` is a `tee(1)`-like utility that additionally writes all of the input it
-receives into rotating log files. Log files are rotated when the reach a
+receives into rotating log files. Log files are rotated when they reach a
 specified size.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use std::env;
+
+pub fn main() {
+    if let Ok(profile) = env::var("PROFILE") {
+        // Used in tests.
+        println!("cargo:rustc-cfg=cargo_profile=\"{}\"", profile);
+    }
+}


### PR DESCRIPTION
77c73771418eb8aa6ab45f5e22f9ec4f3e02361f is the meat of the work.

See commit messages for details.

cc @reashlin, who found the bug.